### PR TITLE
Update and rename npmpublish.yml to npm-publish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,7 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
Updated from created to published for the type of release. We don't want to publish to npm just when a release is created.